### PR TITLE
Chore/add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 [To-Be-Named]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated do=cumentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ MIT License
 Copyright (c) 2025 [To-Be-Named]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated do=cumentation files (the "Software"), to deal
+of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is


### PR DESCRIPTION
This PR adds an MIT License to the project to define the terms of use, distribution, and contributions.  

### Changes:  
- Added a `LICENSE` file with the standard MIT License.  
- Ensured the license reflects the project's scope.  

>[!Note]
> The MIT License allows broad usage, modification, and distribution while requiring attribution.  
> No other changes were made to the repository.  

Closes #5 