### PR TITLE
Add a Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+#### Description
+<!-- What does this PR do? Briefly explain the purpose of your changes -->
+
+#### How to Test
+<!-- Provide clear steps for reviewers to test your changes, including any setup requirements -->
+<!-- [e.g., "1. Run `npm start`, 2. Go to `/login`, 3. Enter test credentials: user=test, pass=1234"] -->
+
+#### Screenshots (if applicable)
+<!-- Attach screenshots or GIFs to show visual changes -->
+<!-- [e.g., "Here’s the new login form: [insert image]"] -->
+
+#### Checklist
+<!-- Mark these items to confirm you’ve checked them -->
+- [ ] I have written tests for my changes, where applicable
+- [ ] No errors or warnings in the console/server logs
+- [ ] I have updated documentation where needed
+
+#### Related Issues
+<!-- List of the related issues using GitHub keywords: 
+https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
+
+[e.g., "Fixes #12", "Closes #14", "Relates #11"]
+-->


### PR DESCRIPTION
This change is aimed at standardising the PR creation process and ensures contributors provide useful information for reviewers.

The template is expected to evolve as the project grows and more contributors join.

It is my understanding we'll only be able to test this when this PR is merged.

Closes #12 